### PR TITLE
Remove EnableExit to prevent the window from closing on exit

### DIFF
--- a/initiate.ps1
+++ b/initiate.ps1
@@ -149,7 +149,7 @@ If ($Deploy) {
 Switch ($TestScope) {
     'Global' {
         $testFile = Join-Path -Path $here -ChildPath "tests\unit\global.unit.tests.ps1"
-        $GlobalResults = Invoke-Pester -Script $testFile -Tag 'Global' -OutputFile "$here\Results\$startTime-Global-unit.xml" -OutputFormat NUnitXml -PassThru -EnableExit
+        $GlobalResults = Invoke-Pester -Script $testFile -Tag 'Global' -OutputFile "$here\Results\$startTime-Global-unit.xml" -OutputFormat NUnitXml -PassThru
         $GlobalResults | Select-Object -Property TagFilter, Time, TotalCount, PassedCount, FailedCount, SkippedCount, PendingCount | Format-Table -AutoSize
     }
 
@@ -157,13 +157,13 @@ Switch ($TestScope) {
         If ($deploy) { Publish-Automation }
 
         $testFile = Join-Path -Path $here -ChildPath "tests\unit\modal.unit.tests.ps1"
-        $ModalResults = Invoke-Pester -Script $testFile -Tag 'Modal' -OutputFile "$here\Results\$startTime-Modal-unit.xml" -OutputFormat NUnitXml -PassThru -EnableExit
+        $ModalResults = Invoke-Pester -Script $testFile -Tag 'Modal' -OutputFile "$here\Results\$startTime-Modal-unit.xml" -OutputFormat NUnitXml -PassThru
         $ModalResults | Select-Object -Property TagFilter, Time, TotalCount, PassedCount, FailedCount, SkippedCount, PendingCount | Format-Table -AutoSize
     }
 
     Default {
         $testFile = Join-Path -Path $here -ChildPath "tests\unit\global.unit.tests.ps1"
-        $GlobalResults = Invoke-Pester -Script $testFile -Tag 'Global' -OutputFile "$here\Results\$startTime-Global-unit.xml" -OutputFormat NUnitXml -PassThru -EnableExit
+        $GlobalResults = Invoke-Pester -Script $testFile -Tag 'Global' -OutputFile "$here\Results\$startTime-Global-unit.xml" -OutputFormat NUnitXml -PassThru
         $GlobalResults | Select-Object -Property TagFilter, Time, TotalCount, PassedCount, FailedCount, SkippedCount, PendingCount | Format-Table -AutoSize
         
         If ($GlobalResults.FailedCount -ne 0) {
@@ -173,7 +173,7 @@ Switch ($TestScope) {
         ElseIf ($deploy) { Publish-Automation }
 
         $testFile = Join-Path -Path $here -ChildPath "tests\unit\modal.unit.tests.ps1"
-        $ModalResults = Invoke-Pester -Script $testFile -Tag 'Modal' -OutputFile "$here\Results\$startTime-Modal-unit.xml" -OutputFormat NUnitXml -PassThru -EnableExit
+        $ModalResults = Invoke-Pester -Script $testFile -Tag 'Modal' -OutputFile "$here\Results\$startTime-Modal-unit.xml" -OutputFormat NUnitXml -PassThru
         $ModalResults | Select-Object -Property TagFilter, Time, TotalCount, PassedCount, FailedCount, SkippedCount, PendingCount | Format-Table -AutoSize
     }
 }


### PR DESCRIPTION
This removes the -EnableExit switch.  Without this the Powershell window or ISE will close on exit.