### PR TITLE
Small spelling change in UI: Clustes -> Clusters

### DIFF
--- a/helpers/UI/vDCBUI.psm1
+++ b/helpers/UI/vDCBUI.psm1
@@ -40,7 +40,7 @@ function vDCBUI {
             </Grid>
             <Grid>
                 <Rectangle Name="mark3" Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" Height="27.976" Margin="0,0,159,0" Visibility="Hidden"/>
-                <Label Content="Clustes and Nodes" Margin="10,0,0,0"/>
+                <Label Content="Clusters and Nodes" Margin="10,0,0,0"/>
             </Grid>
             <Grid>
                 <Rectangle Name="mark4" Fill="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" Height="27.976" Margin="0,0,159,0" Visibility="Hidden"/>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18422723/110026633-ba4e9800-7ce5-11eb-9a57-6f285bc2b5fa.png)

Small spelling mistake Clustes and nodes as opposed to Clusters and nodes