### PR TITLE
Updated driver version check

### DIFF
--- a/Tests/unit/modal.unit.tests.ps1
+++ b/Tests/unit/modal.unit.tests.ps1
@@ -69,7 +69,7 @@ Describe "[Modal Unit]" -Tag Modal {
 
                 ### Verify interface is using at least the recommended driver version
                 It "[SUT: $nodeName]-[RDMAEnabledAdapter: $($thisRDMAEnabledAdapter.Name)]-[Noun: NetAdapter] Driver must use the recommended version ($($thisDriver.MinimumDriverVersion) or later" {
-                    ($actNetAdapterState.NetAdapter | Where-Object Name -eq $thisRDMAEnabledAdapter.Name).DriverVersionString -ge $thisDriver.MinimumDriverVersion | Should be $true
+                    ([System.Version]($actNetAdapterState.NetAdapter | Where-Object Name -eq $thisRDMAEnabledAdapter.Name).DriverVersionString) -ge [System.Version]($thisDriver.MinimumDriverVersion) | Should be $true
                 }
             }
         }
@@ -135,7 +135,7 @@ Describe "[Modal Unit]" -Tag Modal {
 
                     ### Verify interface is using at least the recommended driver version
                     It "[SUT: $nodeName]-[VMSwitch: $($thisCfgVMSwitch.Name)]-[RDMAEnabledAdapter: $($thisRDMAEnabledAdapter.Name)]-[Noun: NetAdapter] Driver must use the recommended version ($($thisDriver.MinimumDriverVersion)) or later" {
-                        ($actNetAdapterState.NetAdapter | Where-Object Name -eq $thisRDMAEnabledAdapter.Name).DriverVersionString -ge $thisDriver.MinimumDriverVersion | Should be $true
+                        ([System.Version]($actNetAdapterState.NetAdapter | Where-Object Name -eq $thisRDMAEnabledAdapter.Name).DriverVersionString) -ge [System.Version]($thisDriver.MinimumDriverVersion) | Should be $true
                     }
                 }
             }


### PR DESCRIPTION
The existing driver version check will fail when a driver has version "1.10.#.#" and the required minimum version is "1.9.#.#" as is the case with the current Intel E810 drivers. Casting the current and minimum driver strings into [System.Version] objects fixed the issue in my testing.